### PR TITLE
Basic CSRF protection

### DIFF
--- a/srht/app.py
+++ b/srht/app.py
@@ -25,6 +25,7 @@ from srht.objects import User
 
 app = Flask(__name__)
 app.secret_key = _cfg("secret_key")
+app.config.update(SESSION_COOKIE_SAMESITE="Lax")
 if _cfg("securecookie") and _cfg("securecookie") == "True":
     app.config.update(SESSION_COOKIE_SECURE=True)
 app.jinja_env.cache = None


### PR DESCRIPTION
Ideally:
- This should be SameSite: Strict to protect GET routes too, although they seem side effect free as far as I can tell
- CSRF tokens should be in use